### PR TITLE
Set visibility of the iframe to hidden

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export function useElementSize(
         sensor.setAttribute('aria-hidden', 'true')
         sensor.tabIndex = -1
         sensor.style.cssText =
-          'position:absolute;top:0;left:0;height:100%;width:100%;pointer-events:none;z-index:-1'
+          'position:absolute;top:0;left:0;height:100%;width:100%;pointer-events:none;z-index:-1;visibility:hidden;'
 
         loadCount++
         loadQueue.add(state)


### PR DESCRIPTION
Chrome has a default style of the iframes that renders borders if this hook is used on an element in the center of the page. Hence adding a CSS property to hide the frame.